### PR TITLE
fix(Transaction Adapter): Add dynamic colour for income and expenses

### DIFF
--- a/app/src/main/java/com/example/budgiebudgettracking/TransactionAdapter.kt
+++ b/app/src/main/java/com/example/budgiebudgettracking/TransactionAdapter.kt
@@ -54,11 +54,18 @@ class TransactionAdapter(
 		// Load receipt thumbnail (if path is non-null)
 		if (!tx.receiptImagePath.isNullOrEmpty()) {
 			Glide.with(holder.itemView)
-			.load(tx.receiptImagePath)
-			.placeholder(R.drawable.ic_camera)
-			.into(holder.receiptImage)
+				.load(tx.receiptImagePath)
+				.placeholder(R.drawable.ic_camera)
+				.into(holder.receiptImage)
 		} else {
 			holder.receiptImage.setImageResource(R.drawable.ic_camera)
+		}
+
+
+		if (tx.isExpense) {
+			holder.amountText.setTextColor(android.graphics.Color.parseColor("#E76F51")) // Expense (negative)
+		} else {
+			holder.amountText.setTextColor(android.graphics.Color.parseColor("#2A9D8F")) // Income (positive)
 		}
 	}
 


### PR DESCRIPTION
Updated TransactionAdapter to set text colour based on transaction type.
- Negative (expense) amounts now display in #E76F51.
- Positive (income) amounts now display in #2A9D8F.